### PR TITLE
Updated "tailor create" instructions

### DIFF
--- a/docs/create/README.md
+++ b/docs/create/README.md
@@ -9,42 +9,47 @@ You can look through some example apps to get a better idea of the different thi
 
 You can look through some [example apps](../../examples) to get a better idea of the different things that are possible.
 
-
 ## Before you begin
 
 ### Get your account into the preview
 
 Enable access to the Stripe preview CLI by sending your account ID to your Stripe contact and requesting access.
- 
+
 You can find your account ID in the top right corner of the [**Account settings** section](https://dashboard.stripe.com/settings/account) in the Dashboard, as shown below:
 
 <img src="./acct_settings.jpg" width="500" />
 
-### Get the forked Stripe CLI 
+### Get the forked Stripe CLI
+
 1. Get the latest build of the Stripe CLI from https://github.com/stripe/tailor-preview/releases/latest.
-1. Download it to a convenient location.
+1. Download and unpack the file to a convenient location.
 1. Move the file to your `/Users/<username>/stripe` folder to avoid getting a warning from Santa.
+1. Rename the file from `stripe` to `stripe-preview`
 1. If you are getting an untrusted warning from MacOS due to the lack of signing, run the `xattr -r -d com.apple.quarantine /Users/<username>/stripe/stripe-preview` and it will remove the flag. See [more for details](https://apple.stackexchange.com/questions/337268/how-can-i-remove-the-downloaded-from-the-internet-security-from-all-files-in-a).
-1. Setup an alias for the preview CLI so you can access it globally.
+1. Setup an alias for the preview CLI so you can access it globally:
+
 ```sh
 alias stripe-preview=/Users/<user>/stripe/stripe-preview
 ```
 
 ## Bootstrap your app
+
 ```sh
 $ stripe-preview tailor create [name]
 ```
 
 This will create a new, minimal tailor.json file.
 
+If you're getting a `Not found` error from the npm registry, run the command again with the `--internal` flag:
+
+```sh
+$ stripe-preview tailor create [name] --internal
+```
+
 ## Now time to use some capabilities
 
-Your basic app has now been bootstrapped, but it does not do much yet. Next for you is to use some of the platform capabilities to add functionality.  
+Your basic app has now been bootstrapped, but it does not do much yet. Next for you is to use some of the platform capabilities to add functionality.
 
 We recommend you to continue with UI extensions for Dashboard.
 
 [Learn more about building apps with UI extensions for Dashboard](../ui-extensions/README.md)
-
-
-
-


### PR DESCRIPTION
* Included missing step of renaming `stripe` to `stripe-preview`
* Included `--internal` flag for the CLI to get the create function working before we publish the browser SDK to the npm registry.