### PR TITLE
Update docs route to build-backend-authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ## 2022-02-11
 - Released version 2.0.3 of the SDK
     - Returns a promise from useRefreshDashboardData that resolves after dashboard data is refreshed.
-    - Adds `fetchStripeSignature` method that optionally accepts additional request payload. Signature can be used to make authenticated request to your app's backend. See [the docs](https://stripe.com/docs/stripe-apps/authenticate) for details.
+    - Adds `fetchStripeSignature` method that optionally accepts additional request payload. Signature can be used to make authenticated request to your app's backend. See [the docs](https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend) for details.
     - Fixes an issue where the test element check method `.is` would sometimes fail to identify a component.
 - Fixed https://github.com/stripe/stripe-apps/issues/104
 

--- a/examples/basic-auth/README.md
+++ b/examples/basic-auth/README.md
@@ -7,7 +7,7 @@ authorization server.
 Because an app cannot at the moment receive an OAuth2 callback or securely save
 auth tokens, we need a server with a storage solution which will store the
 tokens for a user. User identity can be securely validated using
-[signature checking](https://stripe.com/docs/stripe-apps/authenticate), allowing
+[signature checking](https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend), allowing
 tokens to be fetched as needed.
 
 The example backend here is one that keeps the tokens on the server and expects

--- a/examples/basic-auth/backend/src/index.ts
+++ b/examples/basic-auth/backend/src/index.ts
@@ -40,7 +40,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 /**
  * Here we extract the session key used. Because we cannot use cookies to set a secure session id, the
  * only thing we can rely on is stripe's user and account IDs. These will be possible to securely verify
- * using a signed header once this is implemented in the Stripe apps SDK (see https://stripe.com/docs/stripe-apps/authenticate)
+ * using a signed header once this is implemented in the Stripe apps SDK (see https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend)
  */
 const verifyCaller: Handler = (req, res, next) => {
   const sig = req.headers["stripe-signature"];

--- a/examples/github-oauth/packages/backend/src/index.ts
+++ b/examples/github-oauth/packages/backend/src/index.ts
@@ -48,7 +48,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 /**
  * Here we extract the session key used. Because we cannot use cookies to set a secure session id, the
  * only thing we can rely on is stripe's user and account IDs. These will be possible to securely verify
- * using a signed header once this is implemented in the Stripe apps SDK (see https://stripe.com/docs/stripe-apps/authenticate)
+ * using a signed header once this is implemented in the Stripe apps SDK (see https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend)
  */
 const verifyCaller: Handler = (req, res, next) => {
   const sig = req.headers['stripe-signature'];

--- a/examples/shippo-best-rate/src/views/shippo_client.ts
+++ b/examples/shippo-best-rate/src/views/shippo_client.ts
@@ -1,7 +1,7 @@
 /* WARNING! API token-based APIs cannot be safely used from UI Extensions. This example is
  * ok because it's a test token and not sensitive, but if this were to be productionized
  * we'd have to modify this code to be secure. There are two options:
- * - If we control the backend, we can use [Stripe-provided signed payloads](https://site-admin.stripe.com/docs/stripe-apps/authenticate)
+ * - If we control the backend, we can use [Stripe-provided signed payloads](https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend)
  *   to verify the origin of the request.
  * - If we do not control the backend (as is the case in this example), we would need to either
  *   authenticate the user with Shippo using OAuth or write our own backend that communicates


### PR DESCRIPTION
<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->

Devs are going to stripe-apps/authenticate and finding a 404. Content was moved to https://stripe.com/docs/stripe-apps/build-backend#authenticate-ui-to-backend

Instances of linking to broken link: https://github.com/stripe/stripe-apps/search?q=authenticate
## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
Triaged issue 

## Tests
<!-- Test running will eventually be automated, but for now, run the tests manually. -->

Run the typechecker and unit tests on all examples in the repository by running (from the project root):

```
node run-tests
```

- [ ] I have run the tests and they pass
