### PR TITLE
Update Climate Example app readme

### DIFF
--- a/examples/climate/README.md
+++ b/examples/climate/README.md
@@ -23,7 +23,7 @@ link snippet
 ## Using in your own app
 To integrate within your app, follow these steps:
 
-- Copy the files in /src/components (ClimateLinkComponent.tsx, etc) into your own app.
+- Copy the files in /src/components (ClimateLinkComponent.tsx, etc.) into your own app.
 - Add a reference to <ClimateLinkComponent /> in your UI as follows:
 ```
     <ClimateLinkComponent appId="<YOUR APP ID HERE>" />
@@ -40,4 +40,4 @@ Please do not use language that references ‘offsets’ as it pertains to Strip
 - In the best case, we hope that these projects can grow to provide a material portion of the gigatons of carbon removal the world needs to limit a rise in temperature below agreed-upon targets.
 - We select carbon removal projects based on criteria we developed in partnership with our scientific expert advisors, and we rely on our [public application and review process](https://github.com/stripe/carbon-removal-source-materials) instead of verifying through traditional carbon offset verifiers.
 
-Have questions on Stripe Climate? Reach out to us at support@stripe.com
+Have questions on Stripe Climate? Reach out to us at support+climate@stripe.com


### PR DESCRIPTION
<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->
Updating the readme for the Climate Example app to include some usage guidelines

## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
We don't want Stripe Climate to be represented in a misleading way

## Tests
<!-- Test running will eventually be automated, but for now, run the tests manually. -->

Run the typechecker and unit tests on all examples in the repository by running (from the project root):

```
node run-tests
```

- [X] I have run the tests (they don't pass, but it's not related to this PR)

```
st-mzhou3:stripe-apps mzhou$ node run-tests
🔵 Testing example: ./examples/todo


(node:33690) UnhandledPromiseRejectionWarning: Error: Command failed: yarn install --frozen-lockfile
error An unexpected error occurred: "https://registry.yarnpkg.com/@stripe/ui-extension-sdk/-/ui-extension-sdk-7.0.0.tgz: Request failed \"404 Not Found\"".

    at ChildProcess.exithandler (child_process.js:383:12)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1058:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:33690) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:33690) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
