### PR TITLE
[Install-webhooks Example] Keeping env variable names in sync across servers

### DIFF
--- a/examples/install-webhooks/backend/dotnet/Controllers/StripeWebHookController.cs
+++ b/examples/install-webhooks/backend/dotnet/Controllers/StripeWebHookController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Model;
 using Stripe;
+using dotenv.net;
 using dotenv.net.Utilities;
 
 
@@ -13,6 +14,10 @@ namespace dotnet.Controllers;
 [Route("")]
 public class StripeWebHook : ControllerBase
 {
+    public StripeWebHook() 
+    {
+        DotEnv.Load();
+    }
     // This represents a database or other external infrastructure for
     // the purposes of this example. In a production system you would need
     // to set up a true persistent store.

--- a/examples/install-webhooks/backend/ruby/index.rb
+++ b/examples/install-webhooks/backend/ruby/index.rb
@@ -5,7 +5,7 @@ require 'date'
 
 Dotenv.load
 
-Stripe.api_key = ENV['STRIPE_SECRET_KEY']
+Stripe.api_key = ENV['STRIPE_API_KEY']
 set :port, 8080
 
 # This Hash represents a database or other external infrastructure for
@@ -18,7 +18,7 @@ post '/webhook' do
 
   sig = request.env["HTTP_STRIPE_SIGNATURE"]
   payload = request.body.read
-  endpoint_secret = ENV['ENDPOINT_SECRET']
+  endpoint_secret = ENV['STRIPE_WEBHOOK_SECRET']
   event = nil
   
   begin


### PR DESCRIPTION
## Summary
This is just a clean up to make sure env variable names are in sync across servers

## Motivation
Since there is a single instruction on configuring an env file, the variable names used should be in sync across servers.
