### PR TITLE
Update Secret Store examples with expiry feature

### DIFF
--- a/examples/secret-store/backend/README.md
+++ b/examples/secret-store/backend/README.md
@@ -8,10 +8,16 @@ This example Express app shows how to interact with Secret Store from a backend 
 STRIPE_API_KEY=$STRIPE_TEST_KEY node app.js
 ```
 
-## Setting a secret
+## Setting a secret that doesn't expire
 
 ```
 curl localhost:4242/set_secret -d "secret_name"="name" -d "secret_value"="shh" -d "user_id"="usr_5"
+```
+
+## Setting a secret that expires
+
+```
+curl localhost:4242/set_secret -d "secret_name"="name" -d "secret_value"="shh" -d "user_id"="usr_5" -d "secret_expiry"=3490367953
 ```
 
 ## Finding a secret

--- a/examples/secret-store/backend/app.js
+++ b/examples/secret-store/backend/app.js
@@ -10,9 +10,15 @@ app.post('/set_secret', async (req, res) => {
   const userId = req.body.user_id;
   const secretName = req.body.secret_name;
   const secretValue = req.body.secret_value;
+  const secretExpiry = req.body.secret_expiry;
 
   try {
-    const secret = await stripe.apps.secrets.create({scope: { type: 'user', user: userId }, name: secretName, payload: secretValue});
+    const secret = await stripe.apps.secrets.create({
+      scope: { type: 'user', user: userId }, 
+      name: secretName, 
+      payload: secretValue, 
+      expires_at: secretExpiry
+    });
 
     res.status(200).json(secret);
   } catch(e) {


### PR DESCRIPTION
<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->

This PR updates our backend and UI extension examples with the new secret expiry feature.

Tested creating secrets with & without expiration in the backend example:
<img width="1113" alt="Screen Shot 2022-08-08 at 12 01 55 PM" src="https://user-images.githubusercontent.com/109826637/183508886-a5ebe228-79c5-4f27-bc33-e87c8bd8c5e0.png">

Also tested in the UI extension example:

https://user-images.githubusercontent.com/109826637/183508937-63110d26-d16f-4aae-9c13-1b2ba6d2850d.mov


## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->

Docs: 
https://stripe.com/docs/stripe-apps/store-secrets#expiration 
https://stripe.com/docs/api/apps/secret_store/secret_resource#secret_object-expires_at
