### PR TITLE
Update getDropboxToken.ts

### DIFF
--- a/examples/dropbox-oauth-pkce/src/util/getDropboxToken.ts
+++ b/examples/dropbox-oauth-pkce/src/util/getDropboxToken.ts
@@ -1,9 +1,9 @@
 import { addSeconds } from 'date-fns';
 
 import { TokenData } from "./types";
-import { client_id } from '../../config.example';
+import { client_id } from '../../config.example.ts';
 
-const APP_NAME = 'com.example.thisdot-dropbox-oauth-pkce';
+const APP_NAME = 'com.example.dropbox-oauth-pkce';
 const redirectURI = `https://dashboard.stripe.com/test/apps-oauth/${APP_NAME}`;
 export const getDropboxAuthURL = (state: string, challenge: string) =>
   `https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=${client_id}&redirect_uri=${redirectURI}&state=${state}&code_challenge=${challenge}&code_challenge_method=S256`;


### PR DESCRIPTION
Fix Authentication Redirect URL in Dropbox sample to remove reference to "thisdot".

<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
This updates the auth redirect URL to the right value, as specified in the [readme](https://github.com/stripe/stripe-apps/tree/main/examples/dropbox-oauth-pkce) for this sample.

## Motivation
The sample doesn't work as is.
