### PR TITLE
Allow `_` in app id

### DIFF
--- a/schema/stripe-app.schema.json
+++ b/schema/stripe-app.schema.json
@@ -22,7 +22,7 @@
       "description": "The unique identifier for an app, for example \"com.invoicing.myapp\".",
       "markdownDescription": "The unique identifier for an app, for example `com.invoicing.myapp`.",
       "type": "string",
-      "pattern": "^[a-zA-Z0-9\\-\\.]+$"
+      "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
     },
     "version": {
       "description": "An app version that you define. You can use any format you want for version identifiers.",

--- a/schema/test/schema.test.ts
+++ b/schema/test/schema.test.ts
@@ -59,6 +59,14 @@ describe("Validate manifests", () => {
     expect(valid).toBe(false);
   });
 
+  it("accepts underscores in app id", () => {
+    const valid = validate({
+      ...basicManifest,
+      id: "app_id.stripe.com"
+    });
+    expect(valid).toBe(true);
+  });
+
   it("rejects invalid permissions", () => {
     const valid = validate({
       ...basicManifest,


### PR DESCRIPTION
<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->
Updates the JSON schema validation to allow underscores (`_`) in the app id.

## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
Some sample apps include the `_` and do not pass validation. The `_` is allowed in the backend as well.
