### PR TITLE
Enable testing from public forks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 <!-- If this branch is in-progress, start the title with [wip] -->
+<!-- Please note that a maintainer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your change. -->
 
 ## Summary
 <!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->

--- a/.github/workflows/test_schema.yml
+++ b/.github/workflows/test_schema.yml
@@ -1,8 +1,12 @@
 name: Test JSON schema
-on: push
+on:
+  push:
+  pull_request_target:
+    types: [labeled]
 jobs:
   test-schema:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     steps:
       - uses: actions/checkout@v3
       - name: Test schema

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+Welcome, and thank you for your interest in contributing to Stripe Apps!
+
+## Submitting changes
+[Create a new fork of stripe-apps](https://github.com/stripe/stripe-apps/fork) to begin contributing.  Develop your changes on a branch in your new fork and then [open a new pull request](https://github.com/stripe/stripe-apps/compare).  A maintainer will review your pull request and merge it, or request changes if necessary.
+
+Note: a reviewer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your changes.


### PR DESCRIPTION
Requires a label `safe-to-test` is added to PRs by a maintainer

<!-- If this branch is in-progress, start the title with [wip] -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->
- Requires maintainer to add safe-to-test label to run gh actions

## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
- Actions not running on PRs from public forks