### PR TITLE
Remove '[wip]' prompt from README.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!-- If this branch is in-progress, start the title with [wip] -->
 <!-- Please note that a maintainer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your change. -->
 
 ## Summary


### PR DESCRIPTION
<!-- If this branch is in-progress, start the title with [wip] -->
<!-- Please note that a maintainer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your change. -->

## Summary
<!-- What does the code do? What have you changed? If this is a visual change consider including a screenshot/gif. -->

Per the tin.

## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
We don't use the `wip` bot anymore.