### PR TITLE
Update ruby install-webhooks example

### DIFF
--- a/examples/install-webhooks/backend/ruby/README.md
+++ b/examples/install-webhooks/backend/ruby/README.md
@@ -13,7 +13,7 @@ bundle install
 
 2. Run the application
 ```bash
-ruby server.rb
+ruby index.rb
 ```
 
 Server is running on `localhost:8080`

--- a/examples/install-webhooks/backend/ruby/index.rb
+++ b/examples/install-webhooks/backend/ruby/index.rb
@@ -5,7 +5,7 @@ require 'date'
 
 Dotenv.load
 
-Stripe.api_key = ENV['STRIPE_SECRET_KEY']
+Stripe.api_key = ENV['STRIPE_API_KEY']
 set :port, 8080
 
 # This Hash represents a database or other external infrastructure for
@@ -18,7 +18,7 @@ post '/webhook' do
 
   sig = request.env["HTTP_STRIPE_SIGNATURE"]
   payload = request.body.read
-  endpoint_secret = ENV['ENDPOINT_SECRET']
+  endpoint_secret = ENV['STRIPE_WEBHOOK_SECRET']
   event = nil
   
   begin
@@ -37,7 +37,7 @@ post '/webhook' do
   when "account.application.authorized"
     # We also trigger on customer events for testing purposes because
     # application.authorized events cannot be triggered via the CLI yet
-  when "customer.created":
+  when "customer.created"
     accountData = Stripe::Account.retrieve(account)
     accountStore[accountData.id] = { id: accountData.id, name: accountData.settings.dashboard.display_name, dateCreated: Date.today }
 
@@ -56,4 +56,3 @@ get '/accounts' do
   return storedAccount.to_json
   status 200
 end
-


### PR DESCRIPTION
## Summary
Updated readme and fixed a syntax error in the ruby example for the `install-webhooks` example.

## Motivation
The example was not running as expected and the Readme was misleading.
