### PR TITLE
Add missing promotion code schema permissions

### DIFF
--- a/schema/stripe-app.schema.json
+++ b/schema/stripe-app.schema.json
@@ -109,6 +109,8 @@
               "plan_write",
               "product_read",
               "product_write",
+              "promotion_code_read",
+              "promotion_code_write",
               "quote_read",
               "quote_write",
               "report_runs_and_report_types_read",


### PR DESCRIPTION
<!-- Please note that a maintainer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your change. -->

## Summary
Adds missing permissions to the schema.

## Motivation
Such permissions are on the official [permission list.](https://docs.stripe.com/stripe-apps/reference/permissions)