### PR TITLE
Add sandbox_install_compatible to app schema

### DIFF
--- a/schema/stripe-app-local.schema.json
+++ b/schema/stripe-app-local.schema.json
@@ -44,6 +44,9 @@
     "stripe_api_access_type": {
       "$ref": "stripe-app.schema.json#/properties/stripe_api_access_type"
     },
+    "sandbox_install_compatible": {
+      "$ref": "stripe-app.schema.json#/properties/sandbox_install_compatible"
+    },
     "ui_extension": {
       "description": "Configuration options for how to display the app in the Dashboard.",
       "type": "object",

--- a/schema/stripe-app.schema.json
+++ b/schema/stripe-app.schema.json
@@ -115,6 +115,8 @@
               "secret_write",
               "setup_intent_read",
               "setup_intent_write",
+              "shipping_rate_read",
+              "shpping_rate_write",
               "sku_read",
               "sku_write",
               "source_read",
@@ -335,6 +337,11 @@
         "platform"
       ]
     }
+  },
+  "sandbox_install_compatible": {
+    "type": "boolean",
+    "description": "A property that when set to true will allow your app to be installable into a sandbox. Read more about enabling Sandbox support: https://docs.stripe.com/stripe-apps/enable-sandbox-support",
+    "markdownDescription": "A property that when set to true will allow your app to be installable into a sandbox. [Read about Sandbox compatibility](https://docs.stripe.com/stripe-apps/enable-sandbox-support)."
   },
   "$defs": {
     "postInstallActionType": {


### PR DESCRIPTION
## Summary
Adds the sandbox_install_compatible field to the app schema for validations.

Also adds some missing permissions.

## Motivation
<!-- Why are you making this change? This can be a link to a GitHub issue. -->
