### PR TITLE
Fix position of `sandbox_install_compatible`

### DIFF
--- a/schema/stripe-app.schema.json
+++ b/schema/stripe-app.schema.json
@@ -336,12 +336,12 @@
         "oauth",
         "platform"
       ]
+    },
+    "sandbox_install_compatible": {
+      "type": "boolean",
+      "description": "A property that when set to true will allow your app to be installable into a sandbox. Read more about enabling Sandbox support: https://docs.stripe.com/stripe-apps/enable-sandbox-support",
+      "markdownDescription": "A property that when set to true will allow your app to be installable into a sandbox. [Read about Sandbox compatibility](https://docs.stripe.com/stripe-apps/enable-sandbox-support)."
     }
-  },
-  "sandbox_install_compatible": {
-    "type": "boolean",
-    "description": "A property that when set to true will allow your app to be installable into a sandbox. Read more about enabling Sandbox support: https://docs.stripe.com/stripe-apps/enable-sandbox-support",
-    "markdownDescription": "A property that when set to true will allow your app to be installable into a sandbox. [Read about Sandbox compatibility](https://docs.stripe.com/stripe-apps/enable-sandbox-support)."
   },
   "$defs": {
     "postInstallActionType": {

--- a/schema/test/schema.test.ts
+++ b/schema/test/schema.test.ts
@@ -45,7 +45,8 @@ const basicManifest = Object.freeze({
   allowed_redirect_uris: [
     "https://myapp.com/cb",
     "https://localhost:3000/callback",
-  ]
+  ],
+  sandbox_install_compatible: true,
 });
 
 describe("Validate manifests", () => {
@@ -178,4 +179,12 @@ describe("Validate manifests", () => {
     });
     expect(valid).toBe(false);
   });
+
+  it("rejects invalid value for sandbox_install_compatible", () => {
+    const valid = validate({
+      ...basicManifest,
+      sandbox_install_compatible: { enabled: true },
+    });
+    expect(valid).toBe(false);
+  })
 });


### PR DESCRIPTION
<!-- Please note that a maintainer must add the `safe-for-testing` label to your pull request before GitHub actions will run and test your change. -->

## Summary
The property added in #995 is misplaced outside the `properties` object. 
cc: @davidnichol-stripe @fkuo-stripe

## Motivation
At the current state, the property does not pass JSON Schema validation




