### PR TITLE
Add `onboarding` post install action type to JSON schema

### DIFF
--- a/schema/stripe-app.schema.json
+++ b/schema/stripe-app.schema.json
@@ -172,7 +172,10 @@
                   "$ref": "#/$defs/postInstallActionType"
                 },
                 {
-                  "const": "settings"
+                  "oneOf": [
+                    { "const": "onboarding" },
+                    { "const": "settings" }
+                  ]
                 }
               ]
             }

--- a/schema/test/schema.test.ts
+++ b/schema/test/schema.test.ts
@@ -160,11 +160,32 @@ describe("Validate manifests", () => {
     expect(valid).toBe(true);
   });
 
+  it("accepts post-install onboarding action", () => {
+    const valid = validate({
+      ...basicManifest,
+      post_install_action: {
+        type: "onboarding",
+      },
+    });
+    expect(valid).toBe(true);
+  });
+
   it("rejects post-install action url property for settings", () => {
     const valid = validate({
       ...basicManifest,
       post_install_action: {
         type: "settings",
+        url: "https://example.com",
+      },
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("rejects post-install action url property for onboarding", () => {
+    const valid = validate({
+      ...basicManifest,
+      post_install_action: {
+        type: "onboarding",
         url: "https://example.com",
       },
     });


### PR DESCRIPTION
## Summary

Add the `onboarding` post install action type (that is used to [direct users to complete onboarding tasks](https://docs.stripe.com/stripe-apps/post-install-actions#link-to-onboarding) before using an app) to the JSON schema.