### PR TITLE
Add custom_input schema support with input_schema and ui_schema

### DIFF
--- a/schema/stripe-app.schema.yaml
+++ b/schema/stripe-app.schema.yaml
@@ -201,8 +201,51 @@
                   },
                   "custom_input_schema": {
                     "type": "string",
-                    "description": "The custom input schema file path",
-                    "pattern": "^[a-zA-Z0-9_\/\\-\\.]+\\.schema.json$"
+                    "description": "The custom input schema file path (legacy format)",
+                    "pattern": "^[a-zA-Z0-9_\/\\-\\.]+\\.json$"
+                  },
+                  "custom_input": {
+                    "type": "object",
+                    "description": "Custom input configuration with input and UI schemas",
+                    "additionalProperties": false,
+                    "properties": {
+                      "input_schema": {
+                        "type": "object",
+                        "description": "The input schema definition",
+                        "additionalProperties": false,
+                        "required": ["type", "content"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The schema type",
+                            "enum": ["json_schema"]
+                          },
+                          "content": {
+                            "type": "string",
+                            "description": "The schema file path",
+                            "pattern": "^[a-zA-Z0-9_\/\\-\\.]+\\.json$"
+                          }
+                        }
+                      },
+                      "ui_schema": {
+                        "type": "object",
+                        "description": "The UI schema definition (JSONForms format)",
+                        "additionalProperties": false,
+                        "required": ["type", "content"],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The schema type",
+                            "enum": ["jsonforms"]
+                          },
+                          "content": {
+                            "type": "string",
+                            "description": "The UI schema file path",
+                            "pattern": "^[a-zA-Z0-9_\/\\-\\.]+\\.json$"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- Add new `custom_input` object structure for custom workflow actions in the stripe-app manifest schema
- `input_schema`: type `json_schema` with content path to JSON Schema file
- `ui_schema`: type `jsonforms` with content path to JSONForms UI schema file
- Keep legacy `custom_input_schema` field for backwards compatibility
- Relax file pattern from `.schema.json` to `.json` to match actual file naming conventions

## Motivation
Support for dynamic dropdowns in custom actions requires a UI schema (JSONForms format) in addition to the input schema. This change enables the new structured format while maintaining backwards compatibility with existing manifests.

Relates to https://github.com/stripe/stripe-cli-apps-plugin/pull/130
